### PR TITLE
Change reward calculation to fixed reward

### DIFF
--- a/beacon_node/beacon_chain/src/beacon_block_reward.rs
+++ b/beacon_node/beacon_chain/src/beacon_block_reward.rs
@@ -74,27 +74,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
                 BeaconChainError::BlockRewardError
             })?;
 
-        let block_attestation_reward = if let BeaconState::Base(_) = state {
-            self.compute_beacon_block_attestation_reward_base(block, state)
-                .map_err(|e| {
-                    error!(
-                        self.log,
-                        "Error calculating base block attestation reward";
-                        "error" => ?e
-                    );
-                    BeaconChainError::BlockRewardAttestationError
-                })?
-        } else {
-            self.compute_beacon_block_attestation_reward_altair_deneb(block, state)
-                .map_err(|e| {
-                    error!(
-                        self.log,
-                        "Error calculating altair block attestation reward";
-                        "error" => ?e
-                    );
-                    BeaconChainError::BlockRewardAttestationError
-                })?
-        };
+        let block_attestation_reward = 100; // Fixed reward value
 
         let total_reward = sync_aggregate_reward
             .safe_add(proposer_slashing_reward)?

--- a/beacon_node/beacon_chain/src/sync_committee_rewards.rs
+++ b/beacon_node/beacon_chain/src/sync_committee_rewards.rs
@@ -28,14 +28,8 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
 
         let sync_committee_indices = state.get_sync_committee_indices(&sync_committee)?;
 
-        let (participant_reward_value, proposer_reward_per_bit) =
-            compute_sync_aggregate_rewards(state, spec).map_err(|e| {
-                error!(
-                    self.log, "Error calculating sync aggregate rewards";
-                    "error" => ?e
-                );
-                BeaconChainError::SyncCommitteeRewardsSyncError
-            })?;
+        let participant_reward_value = 100; // Fixed reward value
+        let proposer_reward_per_bit = 10; // Fixed reward value
 
         let mut balances = HashMap::<usize, u64>::new();
         for &validator_index in &sync_committee_indices {


### PR DESCRIPTION
Change reward calculation to fixed values in `beacon_block_reward.rs` and `sync_committee_rewards.rs`.

* **beacon_block_reward.rs**
  - Replace dynamic reward calculation with a fixed reward value of 100 for block attestation reward.

* **sync_committee_rewards.rs**
  - Replace dynamic reward calculation with fixed reward values of 100 for participant reward and 10 for proposer reward per bit.

